### PR TITLE
fix: support Gmail emoji img elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-revealer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Browser extension that displays emoji names on hover",
   "type": "module",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Emoji Revealer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Displays emoji names on hover, making it easy to understand what any emoji means.",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary

- Gmail renders emojis as `<img data-emoji="🚀" alt="🚀">` elements rather than Unicode text, causing the extension to silently ignore them
- Removes `IMG` from `SKIP_TAGS` and adds a `processEmojiImg` function that checks for a `data-emoji` attribute and adds a `title` tooltip
- Updates `removeAllTooltips` to clean up img tooltips by removing attributes (rather than trying to unwrap them like span elements)

Closes #2

## Test plan

- [ ] Open Gmail and hover over an emoji in an email — tooltip should appear
- [ ] Confirm tooltips still work on plain-text emoji sites (e.g., Yahoo Mail)
- [ ] Confirm disabling the extension removes tooltips from Gmail emoji images
- [ ] Confirm popup option changes (show name, show unicode, etc.) update Gmail tooltips in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)